### PR TITLE
Various cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 BINDIR=bin
 REPO?=kubevirt
-IMAGE?=kubevirt-csi-driver
+IMAGE?=csi-driver
 TAG?=latest
 REV=$(shell git describe --long --tags --match='v*' --always --dirty)
 

--- a/cmd/kubevirt-csi-driver/kubevirt-csi-driver.go
+++ b/cmd/kubevirt-csi-driver/kubevirt-csi-driver.go
@@ -87,6 +87,7 @@ func handle() {
 		}
 		// systemUUID is the VM ID
 		nodeId = node.Status.NodeInfo.SystemUUID
+		klog.Infof("Node name: %s, Node ID: %s", nodeName, nodeId)
 	}
 
 	driver := service.NewkubevirtCSIDriver(virtClient, nodeId, *infraClusterNamespace)

--- a/deploy/030-node.yaml
+++ b/deploy/030-node.yaml
@@ -26,8 +26,7 @@ spec:
             privileged: true
             allowPrivilegeEscalation: true
           imagePullPolicy: Always
-#          image: quay.io/kubevirt/csi-driver:latest
-          image: quay.io/rgolangh/kubevirt-csi-driver:latest
+          image: quay.io/kubevirt/csi-driver:latest
           args:
             - "--endpoint=unix:/csi/csi.sock"
             - "--namespace=kubevirt-csi-driver"

--- a/deploy/040-controller.yaml
+++ b/deploy/040-controller.yaml
@@ -27,8 +27,7 @@ spec:
       containers:
         - name: csi-driver
           imagePullPolicy: Always
-#          image: quay.io/kubevirt/csi-driver:latest
-          image: quay.io/rgolangh/kubevirt-csi-driver:latest
+          image: quay.io/kubevirt/csi-driver:latest
           args:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--namespace=kubevirt-csi-driver"

--- a/pkg/kubevirt/client.go
+++ b/pkg/kubevirt/client.go
@@ -4,10 +4,7 @@ import (
 	"context"
 	//"time"
 
-	corev1 "k8s.io/api/core/v1"
-	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	kubevirtapiv1 "kubevirt.io/client-go/api/v1"
@@ -23,15 +20,9 @@ type ClientBuilderFuncType func(kubeconfig string) (Client, error)
 // Client is a wrapper object for actual infra-cluster clients: kubernetes and the kubevirt
 type Client interface {
 	Ping(ctx context.Context) error
-	GetNamespace(ctx context.Context, name string) (*corev1.Namespace, error)
-	ListNamespace(ctx context.Context) (*corev1.NamespaceList, error)
-	GetStorageClass(ctx context.Context, name string) (*storagev1.StorageClass, error)
 	ListVirtualMachines(namespace string) ([]kubevirtapiv1.VirtualMachineInstance, error)
 	DeleteDataVolume(namespace string, name string) error
 	CreateDataVolume(namespace string, dataVolume *cdiv1alpha1.DataVolume) (*cdiv1alpha1.DataVolume, error)
-	GetDataVolume(namespace string, name string) (*cdiv1alpha1.DataVolume, error)
-	ListDataVolumes(namespace string) ([]cdiv1alpha1.DataVolume, error)
-	GetVMI(ctx context.Context, namespace string, name string) (*kubevirtapiv1.VirtualMachineInstance, error)
 	AddVolumeToVM(namespace string, vmName string, hotPlugRequest *kubevirtapiv1.HotplugVolumeRequest) error
 	RemoveVolumeFromVM(namespace string, vmName string, hotPlugRequest *kubevirtapiv1.HotplugVolumeRequest) error
 }
@@ -83,60 +74,7 @@ func (c *client) Ping(ctx context.Context) error {
 	_, err := c.kubernetesClient.ServerVersion()
 	return err
 }
-func (c *client) GetNamespace(ctx context.Context, name string) (*corev1.Namespace, error) {
-	return c.kubernetesClient.CoreV1().Namespaces().Get(name, metav1.GetOptions{})
-}
-
-func (c *client) ListNamespace(ctx context.Context) (*corev1.NamespaceList, error) {
-	return c.kubernetesClient.CoreV1().Namespaces().List(metav1.ListOptions{})
-}
-
-func (c *client) GetStorageClass(ctx context.Context, name string) (*storagev1.StorageClass, error) {
-	return c.kubernetesClient.StorageV1().StorageClasses().Get(name, metav1.GetOptions{})
-}
-
-// The functions bellow are used for the destroy command
-// Use Dynamic cluster for those actions (list and delete)
-
-func (c *client) ListVirtualMachineInstancesNames(namespace string, requiredLabels map[string]string) ([]string, error) {
-	opts := &metav1.ListOptions{
-		LabelSelector: labels.FormatLabels(requiredLabels),
-	}
-	instanceList, err := c.virtClient.VirtualMachineInstance(namespace).List(opts)
-	if err != nil {
-		return nil, err
-	}
-
-	var names []string
-	for _, vmi := range instanceList.Items {
-		names = append(names, vmi.Name)
-	}
-	return names, nil
-}
 
 func (c *client) DeleteDataVolume(namespace string, name string) error {
 	return c.virtClient.CdiClient().CdiV1alpha1().DataVolumes(namespace).Delete(name, &metav1.DeleteOptions{})
-}
-
-func (c *client) ListDataVolumes(namespace string) ([]cdiv1alpha1.DataVolume, error) {
-	list, err := c.virtClient.CdiClient().CdiV1alpha1().
-		DataVolumes(namespace).
-		List(metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-	return list.Items, nil
-}
-
-func (c *client) GetDataVolume(namespace string, name string) (*cdiv1alpha1.DataVolume, error) {
-	get, err := c.virtClient.CdiClient().CdiV1alpha1().DataVolumes(namespace).Get(name, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-	return get, nil
-}
-
-func (c *client) GetVMI(_ context.Context, namespace string, name string) (*kubevirtapiv1.VirtualMachineInstance, error) {
-	vm, err := c.virtClient.VirtualMachineInstance(namespace).Get(name, &metav1.GetOptions{})
-	return vm, err
 }

--- a/pkg/kubevirt/client.go
+++ b/pkg/kubevirt/client.go
@@ -49,14 +49,17 @@ func NewClient(config *rest.Config) (Client, error) {
 	return result, nil
 }
 
+//AddVolumeToVM performs a hotplug of a DataVolume to a VM
 func (c *client) AddVolumeToVM(namespace string, vmName string, hotPlugRequest *kubevirtapiv1.HotplugVolumeRequest) error {
 	return c.virtClient.VirtualMachine(namespace).AddVolume(vmName, hotPlugRequest)
 }
 
+//RemoveVolumeFromVM perform hotunplug of a DataVolume from a VM
 func (c *client) RemoveVolumeFromVM(namespace string, vmName string, hotPlugRequest *kubevirtapiv1.HotplugVolumeRequest) error {
 	return c.virtClient.VirtualMachine(namespace).RemoveVolume(vmName, hotPlugRequest)
 }
 
+//ListVirtualMachines fetches a list of VMIs from a namespace
 func (c *client) ListVirtualMachines(namespace string) ([]kubevirtapiv1.VirtualMachineInstance, error) {
 	list, err := c.virtClient.VirtualMachineInstance(namespace).List(&metav1.ListOptions{})
 	if err != nil {
@@ -65,15 +68,18 @@ func (c *client) ListVirtualMachines(namespace string) ([]kubevirtapiv1.VirtualM
 	return list.Items, nil
 }
 
+//CreateDataVolume creates a new DataVolume under a namespace
 func (c *client) CreateDataVolume(namespace string, dataVolume *cdiv1alpha1.DataVolume) (*cdiv1alpha1.DataVolume, error) {
 	return c.virtClient.CdiClient().CdiV1alpha1().DataVolumes(namespace).Create(dataVolume)
 }
 
+//Ping performs a minimal request to the infra-cluster k8s api
 func (c *client) Ping(ctx context.Context) error {
 	_, err := c.kubernetesClient.ServerVersion()
 	return err
 }
 
+//DeleteDataVolume deletes a DataVolume from a namespace by name
 func (c *client) DeleteDataVolume(namespace string, name string) error {
 	return c.virtClient.CdiClient().CdiV1alpha1().DataVolumes(namespace).Delete(name, &metav1.DeleteOptions{})
 }


### PR DESCRIPTION
- deploy: Remove dev image usage
- Remove unused functions from kubevirt/client
- Place the constructor under the struct declaration
- Log node name and ID on start
- Document public functions
