### PR TITLE
build: build a dynamic binary and default to CGO_ENABLED

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test:
 
 .PHONY: build
 build:
-	CGO_ENABLED=0 go build -o $(BINDIR)/kubevirt-csi-driver -ldflags '-extldflags "-static" -X version.Version=$(REV)' cmd/kubevirt-csi-driver/kubevirt-csi-driver.go
+	go build -o $(BINDIR)/kubevirt-csi-driver -ldflags '-X version.Version=$(REV)' cmd/kubevirt-csi-driver/kubevirt-csi-driver.go
 
 .PHONY: verify
 verify: fmt vet


### PR DESCRIPTION
Drop CGO_ENABLED=0 and extldflags -static to get a dynamic binary but
with cgo backends enabled

Signed-off-by: Roy Golan <rgolan@redhat.com>
